### PR TITLE
add nobarrier mount option

### DIFF
--- a/init/fstab.qcom
+++ b/init/fstab.qcom
@@ -9,7 +9,7 @@ product                                      /product                ext4    ro,
 vendor                                       /vendor                 ext4    ro,barrier=1,discard                                                                              wait,logical,first_stage_mount
 odm                                          /odm                    ext4    ro,barrier=1,discard                                                                              wait,logical,first_stage_mount
 /dev/block/bootdevice/by-name/userdata       /data                   ext4    noatime,nosuid,nodev,barrier=0,noauto_da_alloc                                                    latemount,wait,check,encryptable=ice,quota
-/dev/block/bootdevice/by-name/userdata       /data                   f2fs    noatime,nosuid,nodev,discard,fsync_mode=nobarrier                                                 latemount,wait,check,encryptable=ice,quota
+/dev/block/bootdevice/by-name/userdata       /data                   f2fs    noatime,nosuid,nodev,discard,nobarrier,fsync_mode=nobarrier                                                 latemount,wait,check,encryptable=ice,quota
 /dev/block/bootdevice/by-name/modem          /vendor/firmware_mnt    vfat    ro,shortname=lower,uid=0,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0         wait
 /dev/block/bootdevice/by-name/dsp            /vendor/dsp             ext4    ro,nosuid,nodev,barrier=1                                                                         wait
 /dev/block/bootdevice/by-name/persist        /mnt/vendor/persist     ext4    noatime,nosuid,nodev,barrier=1                                                                    wait


### PR DESCRIPTION
Add 'nobarrier' mount option along with 'fsync_mode=nobarrier' to work together.
This option is supported in https://github.com/Rv-Project/android_kernel_xiaomi_sdm845/blob/main/fs/f2fs/super.c